### PR TITLE
Add a Decoder

### DIFF
--- a/opus.cabal
+++ b/opus.cabal
@@ -55,4 +55,5 @@ test-suite hs-mumble-test
                        http-client-tls,
                        zlib,
                        lens,
-                       tar
+                       tar,
+                       process

--- a/opus.cabal
+++ b/opus.cabal
@@ -21,6 +21,7 @@ library
   exposed-modules:     Codec.Audio.Opus.Encoder,
                        Codec.Audio.Opus.Encoder.Conduit,
                        Codec.Audio.Opus.Decoder,
+                       Codec.Audio.Opus.Decoder.Conduit,
                        Codec.Audio.Opus.Types,
                        Codec.Audio.Opus.Internal.Opus
   default-language:    Haskell2010

--- a/opus.cabal
+++ b/opus.cabal
@@ -20,6 +20,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Codec.Audio.Opus.Encoder,
                        Codec.Audio.Opus.Encoder.Conduit,
+                       Codec.Audio.Opus.Decoder,
                        Codec.Audio.Opus.Types,
                        Codec.Audio.Opus.Internal.Opus
   default-language:    Haskell2010

--- a/src/Codec/Audio/Opus/Decoder.hs
+++ b/src/Codec/Audio/Opus/Decoder.hs
@@ -22,7 +22,9 @@ import           Data.ByteString                (ByteString)
 import qualified Data.ByteString                as BS
 import qualified Data.ByteString.Lazy           as BL
 import           Foreign
-import           Foreign.C.Types                (CShort)
+import           Foreign.C.Types                (CShort
+                                                ,CChar
+                                                )
 
 -- | Decoder State
 newtype Decoder = Decoder (ForeignPtr DecoderT, ForeignPtr ErrorCode)
@@ -54,7 +56,7 @@ opusDecode d cfg i =
       fec = cfg ^. deStreamDecodeFec
       conf = cfg ^. deStreamDecoderConfig
       chans = if conf ^. decoderIsStereo then 2 else 1
-      pcm_length = fs * chans * sizeOf(undefined :: CShort)
+      pcm_length = fs * chans
   in liftIO $
   BS.useAsCStringLen i $ \(i', ilen) ->
     allocaArray pcm_length $ \os ->
@@ -67,10 +69,11 @@ opusDecode d cfg i =
           case mbException of
               Nothing -> throwM OpusInvalidPacket
               Just x  -> throwM x
-        else
+        else do
           -- multiply length by two because "os" is CShort i.e. Int16
           -- but CStringLen expects a CChar which is Int8
-          BS.packCStringLen $ (castPtr os, (fromIntegral l) * 2)
+          let multiple = sizeOf (undefined :: CShort) `div` sizeOf (undefined :: CChar)
+          BS.packCStringLen $ (castPtr os, (fromIntegral l) * multiple)
 
 opusDecodeLazy :: (HasDecoderStreamConfig cfg, MonadIO m)
   => Decoder -- ^ 'Decoder' state

--- a/src/Codec/Audio/Opus/Decoder.hs
+++ b/src/Codec/Audio/Opus/Decoder.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Codec.Audio.Opus.Decoder
+  ( -- * Decoder
+    Decoder, OpusException(..)
+    -- ** create
+  , withOpusDecoder, opusDecoderCreate, opusDecoderDestroy
+    -- ** run
+  , opusDecode, opusDecodeLazy
+    -- * re-exports
+  , module Codec.Audio.Opus.Types
+  ) where
+
+import           Codec.Audio.Opus.Internal.Opus
+import           Codec.Audio.Opus.Types
+import           Control.Lens.Fold
+import           Control.Lens.Operators
+import           Control.Monad.Catch
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Resource
+import           Data.ByteString                (ByteString)
+import qualified Data.ByteString                as BS
+import qualified Data.ByteString.Lazy           as BL
+import           Foreign
+import           Foreign.C.Types                (CShort)
+
+-- | Decoder State
+newtype Decoder = Decoder (ForeignPtr DecoderT, ForeignPtr ErrorCode)
+  deriving (Eq, Ord, Show)
+
+-- | allocates and initializes a decoder state.
+opusDecoderCreate :: (HasDecoderConfig cfg, MonadIO m) => cfg -> m Decoder
+opusDecoderCreate cfg = liftIO $ do
+  let cs = if isStereo then 2 else 1
+      sr = cfg ^. (decoderConfig . samplingRate)
+      isStereo = cfg ^. decoderIsStereo
+  err <- mallocForeignPtr
+  d <- withForeignPtr err (c_opus_decoder_create sr cs)
+  d' <- newForeignPtr cp_opus_decoder_destroy d
+  let enc = Decoder (d', err)
+  opusLastError enc >>= maybe (pure enc) throwM
+
+
+
+-- | Decode an Opus frame.
+opusDecode
+  :: (HasDecoderStreamConfig cfg, MonadIO m)
+  => Decoder -- ^ 'Decoder' state
+  -> cfg     -- ^ max data bytes
+  -> ByteString -- ^ input signal (interleaved if 2 channels)
+  -> m ByteString
+opusDecode d cfg i =
+  let fs = cfg ^. deStreamFrameSize
+      fec = cfg ^. deStreamDecodeFec
+      conf = cfg ^. deStreamDecoderConfig
+      chans = if conf ^. decoderIsStereo then 2 else 1
+      pcm_length = fs * chans-- * sizeOf(undefined :: CShort)
+  in liftIO $
+  BS.useAsCStringLen i $ \(i', ilen) ->
+    allocaArray pcm_length $ \os ->
+      runDecoderAction d $ \d' -> do
+        r <- c_opus_decode d' (castPtr i') (fromIntegral ilen) os
+          (fromIntegral fs) (fromIntegral fec)
+        let l = fromIntegral r
+        if l < 0 then do
+          let mbException = preview _ErrorCodeException $ ErrorCode l
+          case mbException of
+              Nothing -> throwM OpusInvalidPacket
+              Just x  -> throwM x
+        else do
+          BS.packCStringLen $ (castPtr os, fromIntegral l)
+
+
+opusDecodeLazy :: (HasDecoderStreamConfig cfg, MonadIO m)
+  => Decoder -- ^ 'Decoder' state
+  -> cfg
+  -> ByteString -- ^ input signal (interleaved if 2 channels)
+  -> m BL.ByteString
+opusDecodeLazy d cfg = fmap BL.fromStrict . opusDecode d cfg
+
+withOpusDecoder :: (HasDecoderConfig cfg) => MonadResource m
+  => cfg
+  -> (Decoder -> IO ())
+  -> m Decoder
+withOpusDecoder cfg a =
+  snd <$> allocate (opusDecoderCreate cfg) a
+
+
+-- | Frees an 'Decoder'. Is normaly called automaticly
+--   when 'Decoder' gets out of scope
+opusDecoderDestroy :: MonadIO m => Decoder -> m ()
+opusDecoderDestroy (Decoder (d, err)) = liftIO $
+  finalizeForeignPtr d >> finalizeForeignPtr err
+
+
+-- | get last error from decoder
+opusLastError :: MonadIO m => Decoder -> m (Maybe OpusException)
+opusLastError (Decoder (_, fp)) =
+  liftIO $ preview _ErrorCodeException <$> withForeignPtr fp peek
+
+type DecoderAction  a = Ptr DecoderT -> IO a
+
+-- | Run an 'DecoderAction'.
+withDecoder' :: MonadIO m =>
+  Decoder -> DecoderAction a -> m (Either OpusException a)
+withDecoder' e@(Decoder (fp_a, _)) m = liftIO $
+  withForeignPtr fp_a $ \a -> do
+    r <- m a
+    le <- opusLastError e
+    pure $ maybe (Right r) Left le
+
+-- | Run an 'DecoderAction'. Might throw an 'OpusException'
+runDecoderAction :: (MonadIO m, MonadThrow m) =>
+  Decoder -> DecoderAction a -> m a
+runDecoderAction d m = withDecoder' d m >>= either throwM pure

--- a/src/Codec/Audio/Opus/Decoder.hs
+++ b/src/Codec/Audio/Opus/Decoder.hs
@@ -54,7 +54,7 @@ opusDecode d cfg i =
       fec = cfg ^. deStreamDecodeFec
       conf = cfg ^. deStreamDecoderConfig
       chans = if conf ^. decoderIsStereo then 2 else 1
-      pcm_length = fs * chans-- * sizeOf(undefined :: CShort)
+      pcm_length = fs * chans * sizeOf(undefined :: CShort)
   in liftIO $
   BS.useAsCStringLen i $ \(i', ilen) ->
     allocaArray pcm_length $ \os ->

--- a/src/Codec/Audio/Opus/Decoder.hs
+++ b/src/Codec/Audio/Opus/Decoder.hs
@@ -69,7 +69,7 @@ opusDecode d cfg i =
         else do
           -- multiply by 2 because "os" is CShort i.e. Int16
           -- but CStringLen expects a CChar which is Int8
-          BS.packCStringLen $ (castPtr os, (fromIntegral l) * 2)
+          BS.packCStringLen $ (castPtr os, (fromIntegral l) * 2 * chans)
 
 opusDecodeLazy :: (HasDecoderStreamConfig cfg, MonadIO m)
   => Decoder -- ^ 'Decoder' state

--- a/src/Codec/Audio/Opus/Decoder.hs
+++ b/src/Codec/Audio/Opus/Decoder.hs
@@ -70,9 +70,10 @@ opusDecode d cfg i =
               Nothing -> throwM OpusInvalidPacket
               Just x  -> throwM x
         else do
-          -- multiply length by two because "os" is CShort i.e. Int16
+          -- multiply length because "os" is CShort i.e. Int16
           -- but CStringLen expects a CChar which is Int8
-          let multiple = sizeOf (undefined :: CShort) `div` sizeOf (undefined :: CChar)
+          let multiple = sizeOf (undefined :: CShort) `div`
+                  sizeOf (undefined :: CChar)
           BS.packCStringLen $ (castPtr os, (fromIntegral l) * multiple)
 
 opusDecodeLazy :: (HasDecoderStreamConfig cfg, MonadIO m)

--- a/src/Codec/Audio/Opus/Decoder.hs
+++ b/src/Codec/Audio/Opus/Decoder.hs
@@ -22,9 +22,6 @@ import           Data.ByteString                (ByteString)
 import qualified Data.ByteString                as BS
 import qualified Data.ByteString.Lazy           as BL
 import           Foreign
-import           Foreign.C.Types                (CShort
-                                                ,CChar
-                                                )
 
 -- | Decoder State
 newtype Decoder = Decoder (ForeignPtr DecoderT, ForeignPtr ErrorCode)
@@ -70,11 +67,9 @@ opusDecode d cfg i =
               Nothing -> throwM OpusInvalidPacket
               Just x  -> throwM x
         else do
-          -- multiply length because "os" is CShort i.e. Int16
+          -- multiply by 2 because "os" is CShort i.e. Int16
           -- but CStringLen expects a CChar which is Int8
-          let multiple = sizeOf (undefined :: CShort) `div`
-                  sizeOf (undefined :: CChar)
-          BS.packCStringLen $ (castPtr os, (fromIntegral l) * multiple)
+          BS.packCStringLen $ (castPtr os, (fromIntegral l) * 2)
 
 opusDecodeLazy :: (HasDecoderStreamConfig cfg, MonadIO m)
   => Decoder -- ^ 'Decoder' state

--- a/src/Codec/Audio/Opus/Decoder/Conduit.hs
+++ b/src/Codec/Audio/Opus/Decoder/Conduit.hs
@@ -1,0 +1,31 @@
+module Codec.Audio.Opus.Decoder.Conduit
+  ( decoderC, decoderLazyC
+  , decoderSink
+  ) where
+
+import           Codec.Audio.Opus.Decoder
+import           Conduit
+import           Control.Lens.Operators
+import           Data.ByteString          (ByteString)
+import qualified Data.ByteString.Lazy     as BL
+import           Data.Conduit.Combinators
+import           Prelude                  (($))
+
+decoderC :: (HasDecoderStreamConfig cfg, MonadResource m) =>
+  cfg -> ConduitT ByteString ByteString m ()
+decoderC cfg = withDecoder (cfg ^. deStreamDecoderConfig) $
+  \d -> mapM (opusDecode d cfg)
+
+decoderLazyC :: (HasDecoderStreamConfig cfg, MonadResource m) =>
+  cfg -> ConduitT ByteString BL.ByteString m ()
+decoderLazyC cfg = withDecoder (cfg ^. deStreamDecoderConfig) $
+  \d -> mapM (opusDecodeLazy d cfg)
+
+decoderSink :: (HasDecoderStreamConfig cfg, MonadResource m) =>
+  cfg -> ConduitT ByteString o m BL.ByteString
+decoderSink cfg = withDecoder (cfg ^. deStreamDecoderConfig) $
+  \d -> foldMapM (opusDecodeLazy d cfg)
+
+withDecoder :: (HasDecoderConfig cfg, MonadResource m) =>
+  cfg -> (Decoder -> ConduitT i o m r) -> ConduitT i o m r
+withDecoder cfg = bracketP (opusDecoderCreate cfg) opusDecoderDestroy

--- a/src/Codec/Audio/Opus/Encoder.hs
+++ b/src/Codec/Audio/Opus/Encoder.hs
@@ -53,15 +53,11 @@ opusEncode e cfg i =
   let fs = cfg ^. streamFrameSize
       n = cfg ^. streamOutSize
   in liftIO $
-  BS.useAsCStringLen i $ \(i',_) -> do
-    print $ "cstring made from bs"
-    allocaArray n $ \os -> do
-      print $ "allocated array of size " <> (show n)
+  BS.useAsCString i $ \i' ->
+    allocaArray n $ \os ->
       runEncoderAction e $ \e' -> do
-        print "encoder is in hand"
         r <- c_opus_encode e' (castPtr i') (fromInteger . toInteger $ fs) os
           (fromInteger . toInteger $ n)
-        print "encoded"
         let l = fromInteger . toInteger $ r
             ol = (os, l)
         if l < 0 then throwM OpusInvalidPacket else

--- a/src/Codec/Audio/Opus/Encoder.hs
+++ b/src/Codec/Audio/Opus/Encoder.hs
@@ -21,6 +21,7 @@ import           Control.Monad.Trans.Resource
 import           Data.ByteString                (ByteString)
 import qualified Data.ByteString                as BS
 import qualified Data.ByteString.Lazy           as BL
+import           Foreign.C.Types                (CShort)
 import           Foreign
 
 -- | Encoder State
@@ -54,7 +55,7 @@ opusEncode e cfg i =
       n = cfg ^. streamOutSize
   in liftIO $
   BS.useAsCString i $ \i' -> do
-    print "cstring made"
+    print $ "cstring made from bs of length" <> (show $ BS.length i) <> " this should be equal to " <> (show $ fs * 2 * sizeOf (undefined :: CShort))
     allocaArray n $ \os -> do
       print $ "allocated array of size " <> (show n)
       runEncoderAction e $ \e' -> do

--- a/src/Codec/Audio/Opus/Encoder.hs
+++ b/src/Codec/Audio/Opus/Encoder.hs
@@ -21,7 +21,6 @@ import           Control.Monad.Trans.Resource
 import           Data.ByteString                (ByteString)
 import qualified Data.ByteString                as BS
 import qualified Data.ByteString.Lazy           as BL
-import           Foreign.C.Types                (CShort)
 import           Foreign
 
 -- | Encoder State
@@ -54,8 +53,8 @@ opusEncode e cfg i =
   let fs = cfg ^. streamFrameSize
       n = cfg ^. streamOutSize
   in liftIO $
-  BS.useAsCString i $ \i' -> do
-    print $ "cstring made from bs of length" <> (show $ BS.length i) <> " this should be equal to " <> (show $ fs * 2 * sizeOf (undefined :: CShort))
+  BS.useAsCStringLen i $ \(i',_) -> do
+    print $ "cstring made from bs"
     allocaArray n $ \os -> do
       print $ "allocated array of size " <> (show n)
       runEncoderAction e $ \e' -> do

--- a/src/Codec/Audio/Opus/Encoder.hs
+++ b/src/Codec/Audio/Opus/Encoder.hs
@@ -53,11 +53,15 @@ opusEncode e cfg i =
   let fs = cfg ^. streamFrameSize
       n = cfg ^. streamOutSize
   in liftIO $
-  BS.useAsCString i $ \i' ->
-    allocaArray n $ \os ->
+  BS.useAsCString i $ \i' -> do
+    print "cstring made"
+    allocaArray n $ \os -> do
+      print $ "allocated array of size " <> (show n)
       runEncoderAction e $ \e' -> do
+        print "encoder is in hand"
         r <- c_opus_encode e' (castPtr i') (fromInteger . toInteger $ fs) os
           (fromInteger . toInteger $ n)
+        print "encoded"
         let l = fromInteger . toInteger $ r
             ol = (os, l)
         if l < 0 then throwM OpusInvalidPacket else

--- a/src/Codec/Audio/Opus/Encoder.hs
+++ b/src/Codec/Audio/Opus/Encoder.hs
@@ -63,7 +63,6 @@ opusEncode e cfg i =
         if l < 0 then throwM OpusInvalidPacket else
           BS.packCStringLen ol
 
-
 opusEncodeLazy :: (HasStreamConfig cfg, MonadIO m)
   => Encoder -- ^ 'Encoder' state
   -> cfg

--- a/src/Codec/Audio/Opus/Internal/Opus.hsc
+++ b/src/Codec/Audio/Opus/Internal/Opus.hsc
@@ -77,6 +77,7 @@ instance Show SamplingRate where
   show (SamplingRate r) = mconcat [show $ r `div` 1000, "kHz"]
 
 data EncoderT
+data DecoderT
 
 
 -- | allocates and initializes an encoder state.
@@ -102,3 +103,27 @@ foreign import ccall unsafe "opus.h opus_encode"
       -> CString       -- ^ output payload
       -> Int32         -- ^ max data bytes
       -> IO Int32      -- ^ number of bytes written or negative in case of error
+
+-- | allocates and initializes a decoder state.
+foreign import ccall unsafe "opus.h opus_decoder_create"
+    c_opus_decoder_create
+      :: SamplingRate -- ^ sampling rate, same as encoder_create
+      -> Int32 -- ^ Number of channels in input signal
+      -> Ptr ErrorCode -- ^ 'ErrorCode' pointer
+      -> IO (Ptr DecoderT)
+
+-- | Frees a 'DecoderT'
+foreign import ccall unsafe "opus.h &opus_decoder_destroy"
+    cp_opus_decoder_destroy
+      :: FunPtr (Ptr DecoderT -> IO ())
+
+foreign import ccall unsafe "opus.h opus_decode"
+    c_opus_decode
+      :: Ptr DecoderT -- ^ Decoder state
+      -> CString      -- ^ Byte array of compressed data
+      -> Int32        -- ^ Exact number of bytes in the payload
+      -> Ptr CShort   -- ^ decoded audio data
+      -> Int32        -- ^ max duration of the frame in samples that can fit
+      -> CInt         -- ^ flag to request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.
+      -> IO Int32     -- ^ Number of decoded samples, or negative in case of error
+

--- a/src/Codec/Audio/Opus/Internal/Opus.hsc
+++ b/src/Codec/Audio/Opus/Internal/Opus.hsc
@@ -120,7 +120,7 @@ foreign import ccall unsafe "opus.h &opus_decoder_destroy"
 foreign import ccall unsafe "opus.h opus_decode"
     c_opus_decode
       :: Ptr DecoderT -- ^ Decoder state
-      -> CString      -- ^ Byte array of compressed data
+      -> Ptr CChar    -- ^ Byte array of compressed data
       -> Int32        -- ^ Exact number of bytes in the payload
       -> Ptr CShort   -- ^ decoded audio data
       -> Int32        -- ^ max duration of the frame in samples that can fit

--- a/src/Codec/Audio/Opus/Types.hs
+++ b/src/Codec/Audio/Opus/Types.hs
@@ -11,8 +11,12 @@ module Codec.Audio.Opus.Types
    -- * EncoderConfig
  , FrameSize
  , EncoderConfig, HasEncoderConfig(..), _EncoderConfig
+   -- * DecoderConfig
+ , DecoderConfig, HasDecoderConfig(..), _DecoderConfig
    -- * StreamConfig
  , StreamConfig, HasStreamConfig(..), _StreamConfig
+   -- * DecoderStreamConfig
+ , DecoderStreamConfig, HasDecoderStreamConfig(..), _DecoderStreamConfig
  ) where
 
 import           Codec.Audio.Opus.Internal.Opus
@@ -79,6 +83,17 @@ instance HasSamplingRate EncoderConfig where
 instance HasCodingMode EncoderConfig where
   codingMode = encoderCodingMode
 
+data DecoderConfig = DecoderConfig
+  { _decoderSamplingRate :: SamplingRate
+  , _decoderIsStereo     :: Bool
+  } deriving (Eq, Show)
+
+makeClassy 'DecoderConfig
+makePrisms 'DecoderConfig
+
+instance HasSamplingRate DecoderConfig where
+  samplingRate = decoderSamplingRate
+
 type FrameSize = Int
 
 
@@ -99,3 +114,19 @@ instance HasSamplingRate StreamConfig where
 
 instance HasCodingMode StreamConfig where
   codingMode = encoderConfig . codingMode
+
+data DecoderStreamConfig = DecoderStreamConfig
+  { _deStreamDecoderConfig :: DecoderConfig
+  , _deStreamFrameSize     :: FrameSize
+  , _deStreamDecodeFec     :: Int
+  } deriving (Eq, Show)
+
+makeClassy ''DecoderStreamConfig
+makePrisms ''DecoderStreamConfig
+
+instance HasDecoderConfig DecoderStreamConfig where
+    decoderConfig = deStreamDecoderConfig
+
+instance HasSamplingRate DecoderStreamConfig where
+    samplingRate = decoderConfig . samplingRate
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -38,10 +38,10 @@ onlyIfOpusCompareExists action = do
     Right (ExitFailure 1, _, _) -> action
     _ -> fail "opus_compare executable not found"
 
-decodeFile :: Decoder -> B.ByteString -> IO B.ByteString
-decodeFile decoder bytes = do
+decodeFile :: DecoderConfig -> B.ByteString -> IO B.ByteString
+decodeFile decoderCfg bytes = do
   decoder <- opusDecoderCreate decoderCfg
-  loop bytes
+  loop decoder bytes
   where
 
     -- | Convert four unsigned bytes to a 32-bit integer. fromIntegral is
@@ -50,15 +50,12 @@ decodeFile decoder bytes = do
     charToInt (b1:b2:b3:b4:[]) = (fromIntegral b1) `shiftL` 24 .|. (fromIntegral b2) `shiftL` 16 .|. (fromIntegral b3) `shiftL` 8 .|. (fromIntegral b4)
     charToInt _ = error "wrong length to convert to int"
 
-    decoderCfg :: DecoderConfig
-    decoderCfg = _DecoderConfig # (opusSR48k, False)
-
     maxPacket, maxFrameSize :: Int
     maxPacket = 1500
     maxFrameSize = 48000 * 2
 
     -- | A simplified port of the official opus_demo.c file's decoding loop
-    loop bytes
+    loop decoder bytes
       | B.length bytes < 8 = pure mempty
       | otherwise = do
         -- lines 649 to 672 in opus_demo.c
@@ -75,7 +72,7 @@ decodeFile decoder bytes = do
         let outputSamples = maxFrameSize
         decoded <- opusDecode decoder (_DecoderStreamConfig # (decoderCfg, outputSamples, 0)) inputData
         -- recursively continue with the rest
-        (decoded <>) <$> loop remaining
+        (decoded <>) <$> loop decoder remaining
 
 main :: IO ()
 main = hspec $ do
@@ -85,11 +82,11 @@ main = hspec $ do
     -- These tests require the opus_compare executable to be present in the
     -- project root, and the opus test vectors, downloaded from the official
     -- opus website.
-    describe "opus mono test vectors" $ do
+    describe "opus mono test vectors" $
       forM_ ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"] $ \file -> do
-        it ("Testing testvector " <> file) $ do
-          decoder <- opusDecoderCreate (_DecoderConfig # (opusSR48k, False))
-          B.readFile ("opus_newvectors/testvector" <> file <> ".bit") >>= decodeFile decoder >>= B.writeFile "tmp.out"
+        it ("mono testvector " <> file) $ do
+          let decoderCfg = _DecoderConfig # (opusSR48k, False)
+          B.readFile ("opus_newvectors/testvector" <> file <> ".bit") >>= decodeFile decoderCfg >>= B.writeFile "tmp.out"
           -- Use readProcessWithExitCode to account for the fact that opus_compare
           -- returns a non-zero exit code if the comparing fails.
           (exitcode1, stdout1, error1) <- readProcessWithExitCode "./opus_compare"
@@ -99,6 +96,27 @@ main = hspec $ do
             ] ""
           (exitcode2, stdout2, error2) <- readProcessWithExitCode "./opus_compare"
             ["-r", "48000"
+            , "opus_newvectors/testvector" <> file <> "m.dec"
+            , "tmp.out"
+            ] ""
+          shouldSatisfy (error1, error2) $ \(a, b) -> "PASSES" `isInfixOf` a || "PASSES" `isInfixOf` b
+
+    describe "opus stereo test vectors" $
+      forM_ ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"] $ \file -> do
+        it ("stereo testvector " <> file) $ do
+          let decoderCfg = _DecoderConfig # (opusSR48k, True)
+          B.readFile ("opus_newvectors/testvector" <> file <> ".bit") >>= decodeFile decoderCfg >>= B.writeFile "tmp.out"
+          -- Use readProcessWithExitCode to account for the fact that opus_compare
+          -- returns a non-zero exit code if the comparing fails.
+          (exitcode1, stdout1, error1) <- readProcessWithExitCode "./opus_compare"
+            [ "-s"
+            , "-r", "48000"
+            , "opus_newvectors/testvector" <> file <> ".dec"
+            , "tmp.out"
+            ] ""
+          (exitcode2, stdout2, error2) <- readProcessWithExitCode "./opus_compare"
+            [ "-s"
+            , "-r", "48000"
             , "opus_newvectors/testvector" <> file <> "m.dec"
             , "tmp.out"
             ] ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,8 +1,16 @@
 module Main(main) where
 
 import           Codec.Audio.Opus.Encoder
+import           Codec.Audio.Opus.Decoder
 import           Control.Lens.Operators
--- import qualified Data.ByteString          as BS
+import           Control.Exception
+import           Control.Monad (guard, forM_)
+import qualified Data.ByteString          as B
+import           Data.Bits
+import           Data.List
+import           Data.Word (Word8)
+import           System.Exit
+import           System.Process
 import           Test.Hspec
 
 
@@ -23,11 +31,72 @@ testEncoderCreate cfg =
      opusEncoderCreate cfg >>= (`shouldSatisfy` const True)
 
 
+onlyIfOpusCompareExists :: IO () -> IO ()
+onlyIfOpusCompareExists action = do
+  result <- try $ readProcessWithExitCode "./opus_compare" [] ""
+  case (result :: Either IOException (ExitCode, String, String)) of
+    Right (ExitFailure 1, _, _) -> action
+    _ -> fail "opus_compare executable not found"
+
+decodeFile :: Decoder -> B.ByteString -> IO B.ByteString
+decodeFile decoder bytes = do
+  decoder <- opusDecoderCreate decoderCfg
+  loop bytes
+  where
+
+    -- | Convert four unsigned bytes to a 32-bit integer. fromIntegral is
+    -- applied to each byte before shifting to not lose any bits.
+    charToInt :: [Word8] -> Int
+    charToInt (b1:b2:b3:b4:[]) = (fromIntegral b1) `shiftL` 24 .|. (fromIntegral b2) `shiftL` 16 .|. (fromIntegral b3) `shiftL` 8 .|. (fromIntegral b4)
+    charToInt _ = error "wrong length to convert to int"
+
+    decoderCfg :: DecoderConfig
+    decoderCfg = _DecoderConfig # (opusSR48k, False)
+
+    maxPacket, maxFrameSize :: Int
+    maxPacket = 1500
+    maxFrameSize = 48000 * 2
+
+    loop bytes
+      | B.length bytes < 8 = pure mempty
+      | otherwise = do
+        let inputLen = charToInt $ B.unpack $ B.take 4 bytes
+        guard $ inputLen <= maxPacket && inputLen >= 0 -- invalid payload length
+
+        let inputEncFinalRange = charToInt $ B.unpack $ B.take 4 $ B.drop 4 bytes
+        let (inputData, remaining) = B.splitAt inputLen $ B.drop 8 bytes
+        guard $ inputLen == B.length inputData -- ran out of input, expecting inputLen but got B.length bytes
+
+        guard $ inputLen /= 0 -- lost packets are not supported for now in this test
+
+        -- assumptions: no lost packets. no inband fec.
+        let outputSamples = maxFrameSize
+        decoded <- opusDecode decoder (_DecoderStreamConfig # (decoderCfg, outputSamples, 0)) inputData
+        (decoded <>) <$> loop remaining
 
 main :: IO ()
 main = hspec $ do
   describe "opusEncoderCreate" $
     seqWithCfgs testEncoderCreate
+  around_ onlyIfOpusCompareExists $ do
+    describe "opus mono test vectors" $ do
+      forM_ ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"] $ \file -> do
+        it ("Testing testvector " <> file) $ do
+          decoder <- opusDecoderCreate (_DecoderConfig # (opusSR48k, False))
+          B.readFile ("opus_newvectors/testvector" <> file <> ".bit") >>= decodeFile decoder >>= B.writeFile "tmp.out"
+          -- Use readProcessWithExitCode to account for the fact that opus_compare
+          -- returns a non-zero exit code if the comparing fails.
+          (exitcode1, stdout1, error1) <- readProcessWithExitCode "./opus_compare"
+            ["-r", "48000"
+            , "opus_newvectors/testvector" <> file <> ".dec"
+            , "tmp.out"
+            ] ""
+          (exitcode2, stdout2, error2) <- readProcessWithExitCode "./opus_compare"
+            ["-r", "48000"
+            , "opus_newvectors/testvector" <> file <> "m.dec"
+            , "tmp.out"
+            ] ""
+          shouldSatisfy (error1, error2) $ \(a, b) -> "PASSES" `isInfixOf` a || "PASSES" `isInfixOf` b
 
 
 {-


### PR DESCRIPTION
Hello Markus!

I found your library while searching for OPUS bindings for Haskell. Your encoder has been really useful.

As I see it, the code only has an Encoder, but I'd love to decode some OPUS audio as well. So here's a pull request!

## Changes in this PR

- Added `Codec.Audio.Opus.Decoder`, which mirrors the Encoder variant for the most part, but also all specs in the [OPUS API PDF](https://opus-codec.org/docs/opus_api-1.3.1.pdf)
- Added `Codec.Audio.Opus.Decoder.Conduit`, which mirrors the Encoder variant closely.
- Added test vector tests for the new decoder, which mirrors the [run_vectors.sh](https://github.com/xiph/opus/blob/master/tests/run_vectors.sh) file in the OPUS repo

## Decoder tests

The tests require `opus_compare` executable in the project root (which can be obtained by compiling [this file](https://github.com/xiph/opus/blob/master/src/opus_compare.c)), and the new opus test vectors (https://opus-codec.org/static/testvectors/opus_testvectors-rfc8251.tar.gz), but once those are in place, passes properly:

<img width="990" alt="Screenshot 2022-01-11_21-04-38" src="https://user-images.githubusercontent.com/60749079/149022920-7397a53f-a738-4499-822b-94f19a40055a.png">

I would've loved to add similar tests for the Encoder, but the original run_vectors.sh only had decoder testing so I haven't pursued further.

I hope you can take a look/review it, and hopefully merge it in!